### PR TITLE
Fix parsing of template <typename F>

### DIFF
--- a/cern-root-mode.el
+++ b/cern-root-mode.el
@@ -156,7 +156,7 @@
 (defun cern-root--preinput-clean (input)
   "Clean INPUT before sending to the process."
   ;; move the template definition onto the same line as the function declaration
-  (replace-regexp-in-string "template<\\(.*\\)>\n" "template<\\1>" (format "%s" input)))
+  (replace-regexp-in-string "template\s*<\\(.*\\)>\n" "template<\\1>" (format "%s" input)))
 
 (defun cern-root--send-string (proc input)
   "Send INPUT to the ROOT repl running as PROC."

--- a/tests/test-cern-root-mode.el
+++ b/tests/test-cern-root-mode.el
@@ -58,6 +58,16 @@ void test() {
     m.print_my_name();
 }")
 
+(defconst test-file-4
+  "template      <typename F>
+struct Person {
+  F age;
+};
+
+double test() {
+    Person<double> p = { 54.4 };
+    return p.age;
+}")
 ;;; begin tests
 
 (ert-deftest cern-root-test-push-new ()
@@ -106,3 +116,7 @@ void test() {
 (ert-deftest cern-root-test-root-file-3 ()
   "Tests that test-file-3 can be sent to the REPL and the correct result is returned."
   (do-test-file test-file-3 "My Fair Lady\n"))
+
+(ert-deftest cern-root-test-root-file-4 ()
+  "Tests that a templated struct can be parsed."
+  (do-test-file test-file-4 "(double) 54.400000\n"))


### PR DESCRIPTION
Thanks for the project!

Functions or structs with space between `template` and `<` were not being parsed.
This fixes this and adds a test  parsing a templated struct.