### PR TITLE
Develop/better parsing

### DIFF
--- a/cern-root-mode.el
+++ b/cern-root-mode.el
@@ -153,10 +153,29 @@
   "Send INPUT to an inferior REPL running as PROC."
   (comint-send-string proc (format "%s\n" input)))
 
+(defun cern-root--clean-strip-comment (input)
+  "Strip out the comments in INPUT."
+  (replace-regexp-in-string "\/\\*\\(\n.*?\\)*\\*\/" "" ; multi-line comments
+                            (replace-regexp-in-string "\/\/.*" "" input)))
+
+(defun cern-root--clean-to-one-line (input)
+  "Convert INPUT to a single line of text."
+  (replace-regexp-in-string "\n" "" input))
+
+(defun cern-root--clean-normalise-brace-style (input)
+  "Normalise the brace style in INPUT to K&R."
+  (replace-regexp-in-string "\s?\n{" " {" input))
+
+(defun cern-root--clean-fix-templates (input)
+  "Fix templates in INPUT."
+  (replace-regexp-in-string "template\s*<\\(.*\\)>\n" "template<\\1>" (format "%s" input)))
+
 (defun cern-root--preinput-clean (input)
   "Clean INPUT before sending to the process."
   ;; move the template definition onto the same line as the function declaration
-  (replace-regexp-in-string "template\s*<\\(.*\\)>\n" "template<\\1>" (format "%s" input)))
+  (cern-root--clean-normalise-brace-style
+   (cern-root--clean-fix-templates
+    (cern-root--clean-strip-comment input))))
 
 (defun cern-root--send-string (proc input)
   "Send INPUT to the ROOT repl running as PROC."

--- a/tests/test-cern-root-mode.el
+++ b/tests/test-cern-root-mode.el
@@ -70,11 +70,18 @@ double test() {
 }")
 
 (defconst test-file-5
-  "float decay(float val)
+  "float test(void)
 {
+  float val = 20.; // this is a test
+  /*
+   * This is a multiline comment
+   */
   return exp(-val);
-}
-")
+  /*
+   * this is another comment.
+   */ 
+}")
+
 ;;; begin tests
 
 (ert-deftest cern-root-test-push-new ()
@@ -129,5 +136,5 @@ double test() {
   (do-test-file test-file-4 "(double) 54.400000\n"))
 
 (ert-deftest cern-root-test-root-file-5 ()
-  "Tests that a different curly-braces style can be parsed."
-  (do-test-file test-file-5 "(double) 50.\n"))
+  "Tests that a different curly-braces style and comments can be parsed."
+  (do-test-file test-file-5 "(float) 2.06115e-09f\n"))

--- a/tests/test-cern-root-mode.el
+++ b/tests/test-cern-root-mode.el
@@ -68,6 +68,13 @@ double test() {
     Person<double> p = { 54.4 };
     return p.age;
 }")
+
+(defconst test-file-5
+  "float decay(float val)
+{
+  return exp(-val);
+}
+")
 ;;; begin tests
 
 (ert-deftest cern-root-test-push-new ()
@@ -120,3 +127,7 @@ double test() {
 (ert-deftest cern-root-test-root-file-4 ()
   "Tests that a templated struct can be parsed."
   (do-test-file test-file-4 "(double) 54.400000\n"))
+
+(ert-deftest cern-root-test-root-file-5 ()
+  "Tests that a different curly-braces style can be parsed."
+  (do-test-file test-file-5 "(double) 50.\n"))


### PR DESCRIPTION
Fix parsing for different brace style. This comment normalises the brace style to be consistent and what the Cling repl expects.

For example:
```c++
int add(int a, int b)
{
  return a+b;
}
```

Will be normalised into:

```c++
int add(int a, int b) {
  return a+b;
}
```

as the text is sent to the repl.